### PR TITLE
Frontpage check with enabled language filter

### DIFF
--- a/titlemanager.php
+++ b/titlemanager.php
@@ -27,10 +27,12 @@ class plgSystemTitlemanager extends JPlugin
 			return;
 		}
 
-		$params   = $this->params;
-		$document = JFactory::getDocument();
-		$menu     = $app->getMenu();
-		$is_frontpage = ($menu->getActive() == $menu->getDefault());
+		$params   	= $this->params;
+		$document 	= JFactory::getDocument();
+		$lang_code 	= $app->getLanguageFilter() ? JFactory::getLanguage()->getTag() : null;
+		$menu 		= $app->getMenu();
+		$active_menu 	= $menu->getActive();
+		$is_frontpage 	= ($active_menu->id == $menu->getDefault($lang_code)->id AND $active_menu->query['view'] == $app->input->getCmd('view'));
 		
 		$sitename = $params->get('sitename') ? $params->get('sitename') : $app->getCfg('sitename');
 		if ($is_frontpage) {


### PR DESCRIPTION
Extended code which would work also when Joomla Language Filter plugin is enabled. 
Also when your home page is type of Joomla Category Blog then when you go to article from this page then it should not be detected as home page - check query view.
